### PR TITLE
Add python version check

### DIFF
--- a/periodic/periodic.py
+++ b/periodic/periodic.py
@@ -4,8 +4,11 @@
 
 import asyncio
 import logging
+import sys
 from contextlib import suppress
 from typing import Callable, Awaitable
+
+assert sys.hexversion >= 0x03070000, "Periodic package requires on Python 3.7 or above"
 
 logger = logging.getLogger('periodic')
 


### PR DESCRIPTION
1) download & install asyncio-periodic
2) put readme sample into file
3) run it
4) get "AttributeError: module 'asyncio' has no attribute 'create_task'"
5) google it
6) found out that periodic requires Python 3.7 but you have 3.6
7) write PR so periodic could say about requirements by itself
8) waiting for approve and merge 8-)